### PR TITLE
[EXT] `producer` and `consumer` span kinds

### DIFF
--- a/src/OpenTracing/Ext/Tags.php
+++ b/src/OpenTracing/Ext/Tags.php
@@ -18,6 +18,16 @@ const SPAN_KIND_RPC_CLIENT = 'client';
 const SPAN_KIND_RPC_SERVER = 'server';
 
 /**
+ * Marks a span as representing the producer within a messaging context
+ */
+const SPAN_KIND_MESSAGE_BUS_PRODUCER = 'producer';
+
+/**
+ * Marks a span as representing the consumer within a messaging context
+ */
+const SPAN_KIND_MESSAGE_BUS_CONSUMER = 'consumer';
+
+/**
  * Component is a low-cardinality identifier of the module, library,
  * or package that is generating a span.
  */


### PR DESCRIPTION
In https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table it is clearly stated that spans not only consist of RPC client and server relationships, but also  producer and consumer relationships when you are in a messaging context.

This PR adds those missing Tag constants as `SPAN_KIND_MESSAGE_BUS_PRODUCER` and `SPAN_KIND_MESSAGE_BUS_CONSUMER`.