### PR TITLE
Adds convinient methods for the SpanReference for coherence

### DIFF
--- a/src/OpenTracing/SpanReference.php
+++ b/src/OpenTracing/SpanReference.php
@@ -73,6 +73,22 @@ final class SpanReference
     }
 
     /**
+     * @return bool
+     */
+    public function isTypeChildOf()
+    {
+        return $this->type === self::CHILD_OF;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTypeFollowsFrom()
+    {
+        return $this->type === self::FOLLOWS_FROM;
+    }
+
+    /**
      * Checks whether a SpanReference is of one type.
      *
      * @param string $type the type for the reference


### PR DESCRIPTION
This PR adds `isType` methods to keep coherence with the creation methods.

Ping @felixfbecker @beberlei