### PR TITLE
Removes per-type creation methods from SpanReference.

### DIFF
--- a/src/OpenTracing/SpanReference.php
+++ b/src/OpenTracing/SpanReference.php
@@ -45,26 +45,6 @@ final class SpanReference
     }
 
     /**
-     * @param SpanContext|Span $context
-     * @throws InvalidReferenceArgument when context is invalid
-     * @return SpanReference
-     */
-    public static function createAsChildOf($context)
-    {
-        return new self(self::CHILD_OF, self::extractContext($context));
-    }
-
-    /**
-     * @param SpanContext|Span $context
-     * @throws InvalidReferenceArgument when context is invalid
-     * @return SpanReference
-     */
-    public static function createAsFollowsFrom($context)
-    {
-        return new self(self::FOLLOWS_FROM, self::extractContext($context));
-    }
-
-    /**
      * @return SpanContext
      */
     public function getContext()

--- a/tests/Unit/SpanReferenceTest.php
+++ b/tests/Unit/SpanReferenceTest.php
@@ -9,6 +9,8 @@ use PHPUnit_Framework_TestCase;
 
 final class SpanReferenceTest extends PHPUnit_Framework_TestCase
 {
+    const REFERENCE_TYPE = 'ref_type';
+
     public function testCreateASpanReferenceFailsOnInvalidContext()
     {
         $context = 'invalid_context';
@@ -27,19 +29,11 @@ final class SpanReferenceTest extends PHPUnit_Framework_TestCase
         SpanReference::create('', $context);
     }
 
-    public function testASpanReferenceCanBeCreatedAsChildOf()
+    public function testASpanReferenceCanBeCreatedAsACustomType()
     {
         $context = new NoopSpanContext();
-        $reference = SpanReference::createAsChildOf($context);
+        $reference = SpanReference::create(self::REFERENCE_TYPE, $context);
         $this->assertSame($context, $reference->getContext());
-        $this->assertTrue($reference->isType('child_of'));
-    }
-
-    public function testASpanReferenceCanBeCreatedAsFollowsFrom()
-    {
-        $context = new NoopSpanContext();
-        $reference = SpanReference::createAsFollowsFrom($context);
-        $this->assertSame($context, $reference->getContext());
-        $this->assertTrue($reference->isType('follows_from'));
+        $this->assertTrue($reference->isType(self::REFERENCE_TYPE));
     }
 }


### PR DESCRIPTION
This PR follows from https://github.com/opentracing/opentracing-php/pull/12#issuecomment-320865558

Ping @felixfbecker @yurishkuro