### PR TITLE
Removes an invalid return annotation

### DIFF
--- a/src/OpenTracing/Span.php
+++ b/src/OpenTracing/Span.php
@@ -20,7 +20,6 @@ interface Span
      * @param float|int|\DateTimeInterface|null $finishTime if passing float or int
      * it should represent the timestamp (including as many decimal places as you need)
      * @param array $logRecords
-     * @return mixed
      */
     public function finish($finishTime = null, array $logRecords = []);
 


### PR DESCRIPTION
`Span::finish` does not return anything. We should remove the annotation here.

Ping @felixfbecker @beberlei