### PR TITLE
Adds null as a valid return value when calling SpanContext::getBaggageItem

### DIFF
--- a/src/OpenTracing/SpanContext.php
+++ b/src/OpenTracing/SpanContext.php
@@ -16,8 +16,11 @@ use IteratorAggregate;
 interface SpanContext extends IteratorAggregate
 {
     /**
+     * Returns the value of a baggage item based on its key. If there is no
+     * value with such key it will return null.
+     *
      * @param string $key
-     * @return string
+     * @return string|null
      */
     public function getBaggageItem($key);
 

--- a/src/OpenTracing/Tracer.php
+++ b/src/OpenTracing/Tracer.php
@@ -4,6 +4,7 @@ namespace OpenTracing;
 
 use OpenTracing\Carriers\HttpHeaders;
 use OpenTracing\Carriers\TextMap;
+use OpenTracing\Exceptions\InvalidReferencesSet;
 use OpenTracing\Exceptions\InvalidSpanOption;
 use OpenTracing\Exceptions\SpanContextNotFound;
 use OpenTracing\Exceptions\UnsupportedFormat;
@@ -29,6 +30,7 @@ interface Tracer
      * @param array|SpanOptions $options
      * @return Span
      * @throws InvalidSpanOption for invalid option
+     * @throws InvalidReferencesSet for invalid references set
      */
     public function startSpan($operationName, $options);
 


### PR DESCRIPTION
There is a not clear strategy for when calling `SpanContext::getBaggageItem` and there is not value for such key. **Python API** returns `None` (see https://github.com/opentracing/opentracing-python/blob/master/opentracing/span.py#L190) so we could safely return a `null`.

Ping @yurishkuro @felixfbecker @beberlei