### PR TITLE
Adds default value for spanOptions when creating a span.

### DIFF
--- a/src/OpenTracing/SpanOptions.php
+++ b/src/OpenTracing/SpanOptions.php
@@ -31,7 +31,7 @@ final class SpanOptions
     public static function create(array $options)
     {
         $spanOptions = new self();
-        
+
         foreach ($options as $key => $value) {
             switch ($key) {
                 case 'child_of':

--- a/src/OpenTracing/Tracer.php
+++ b/src/OpenTracing/Tracer.php
@@ -27,7 +27,12 @@ interface Tracer
 
     /**
      * @param string $operationName
-     * @param array|SpanOptions $options
+     * @param array|SpanOptions $options A set of optional parameters:
+     *   - Zero or more references to related SpanContexts, including a shorthand for ChildOf and
+     *     FollowsFrom reference types if possible.
+     *   - An optional explicit start timestamp; if omitted, the current walltime is used by default
+     *     The default value should be set by the vendor.
+     *   - Zero or more tags
      * @return Span
      * @throws InvalidSpanOption for invalid option
      * @throws InvalidReferencesSet for invalid references set

--- a/src/OpenTracing/Tracer.php
+++ b/src/OpenTracing/Tracer.php
@@ -32,7 +32,7 @@ interface Tracer
      * @throws InvalidSpanOption for invalid option
      * @throws InvalidReferencesSet for invalid references set
      */
-    public function startSpan($operationName, $options);
+    public function startSpan($operationName, $options = []);
 
     /**
      * @param SpanContext $spanContext


### PR DESCRIPTION
While working in the `OT` <> `Zipkin` bridge I found very inconvenient the fact that I should always need to pass a value for `$spanOptions` even if there is no values on it.

Another important concern here is the default start timestamp in the `SpanOptions`. As a vendor agnostic spec we can not set a default timestamp as of the unit depends on the vendor: ex. Zipkin uses microtime by default whereas datadog uses nanotime and other vendors could use a different one so I added documentation to the `startSpan` method.

Ping @yurishkuro @felixfbecker @beberlei