### PR TITLE
Replaces flush function hook in documentation.

### DIFF
--- a/src/OpenTracing/Tracer.php
+++ b/src/OpenTracing/Tracer.php
@@ -58,8 +58,8 @@ interface Tracer
      * or use the call to fastcgi_finish_request in order to not to delay the end
      * of the request to the client.
      *
+     * @see register_shutdown_function()
      * @see fastcgi_finish_request()
-     * @see https://www.google.com/search?q=message+bus+php
      */
     public function flush();
 }


### PR DESCRIPTION
`register_shutdown_function` is the most common function for this case, message bus libraries are often using it so lets point out the main function.