### PR TITLE
removes fromHeaders in order to use fromRequest.

### DIFF
--- a/src/OpenTracing/Carriers/HttpHeaders.php
+++ b/src/OpenTracing/Carriers/HttpHeaders.php
@@ -9,13 +9,11 @@ use Psr\Http\Message\RequestInterface;
 
 final class HttpHeaders implements Reader, Writer
 {
-    private $items = [];
+    private $items;
 
-    private function __construct(array $headers)
+    private function __construct(array $items)
     {
-        foreach ($headers as $key => $value) {
-            $this->items[(string) $key] = (string) $value;
-        }
+        $this->items = $items;
     }
 
     /**
@@ -26,18 +24,14 @@ final class HttpHeaders implements Reader, Writer
     {
         return new self(
             array_map(function ($values) {
-                return $values[0];
+                return implode(', ', $values);
             }, $request->getHeaders())
         );
     }
 
-    /**
-     * @param array|string[] $headers
-     * @return HttpHeaders
-     */
-    public static function fromHeaders(array $headers)
+    public static function fromGlobals()
     {
-        return new self($headers);
+        return new self(getallheaders());
     }
 
     /**

--- a/tests/Unit/Carriers/HttpHeadersTest.php
+++ b/tests/Unit/Carriers/HttpHeadersTest.php
@@ -13,17 +13,6 @@ final class HttpHeadersTest extends PHPUnit_Framework_TestCase
 {
     const TEST_HEADERS = ['foo' => 'bar'];
 
-    public function testCreationWithHeadersHasTheExpectedValues()
-    {
-        $headers = self::TEST_HEADERS;
-        $httpHeaders = HttpHeaders::fromHeaders($headers);
-
-        foreach ($httpHeaders as $key => $value) {
-            $this->assertEquals('foo', $key);
-            $this->assertEquals('bar', $value);
-        }
-    }
-
     public function testCreationFromRequestHasTheExpectedValues()
     {
         $request = new Request('GET', '', self::TEST_HEADERS);


### PR DESCRIPTION
The aim of this PR is to make explicit we support headers in the PSR way. The reason why I removed the `fromHeaders` and went for the `fromRequest` is because it makes it explicit the usage of the PSR request whereas headers was just mimicking `text_map` so in my opinion this is more expressive.

Relates to #31

Ping @felixfbecker  @beberlei @lvht