### PR TITLE
Introduce setTag method for a Span interface and get rid of setTags

### DIFF
--- a/src/OpenTracing/NoopSpan.php
+++ b/src/OpenTracing/NoopSpan.php
@@ -42,7 +42,7 @@ final class NoopSpan implements Span
     /**
      * {@inheritdoc}
      */
-    public function setTags(array $tags)
+    public function setTag($key, $value)
     {
     }
 

--- a/src/OpenTracing/Span.php
+++ b/src/OpenTracing/Span.php
@@ -45,17 +45,19 @@ interface Span
     public function overwriteOperationName($newOperationName);
 
     /**
-     * Sets tags to the Span in key => value format, key must be a string and tag must be either
-     * a string, a boolean value, or a numeric type.
+     * Adds a tag to the span.
+     *
+     * If there is a pre-existing tag set for key, it is overwritten.
      *
      * As an implementor, consider using "standard tags" listed in {@see \OpenTracing\Tags}
      *
      * If the span is already finished, a warning should be logged.
      *
-     * @param array $tags
+     * @param string $key
+     * @param string|bool|int|float $value
      * @return void
      */
-    public function setTags(array $tags);
+    public function setTag($key, $value);
 
     /**
      * Adds a log record to the span in key => value format, key must be a string and tag must be either


### PR DESCRIPTION
Having setTags instead of setTag means that you would have to be aware of tags that are set in order to add aditional tag to a span. But that is not the case if we expose an interface to set just a single tag.

All other opentracing libraries also have setTag exposed instead of setTags so this helps to have more consistency between libraries.

Closes #51