### PR TITLE
Delete $logRecords argument from Span::finish()

### DIFF
--- a/src/OpenTracing/NoopSpan.php
+++ b/src/OpenTracing/NoopSpan.php
@@ -28,7 +28,7 @@ final class NoopSpan implements Span
     /**
      * {@inheritdoc}
      */
-    public function finish($finishTime = null, array $logRecords = [])
+    public function finish($finishTime = null)
     {
     }
 

--- a/src/OpenTracing/Span.php
+++ b/src/OpenTracing/Span.php
@@ -32,10 +32,9 @@ interface Span
      *
      * @param float|int|\DateTimeInterface|null $finishTime if passing float or int
      * it should represent the timestamp (including as many decimal places as you need)
-     * @param array $logRecords
      * @return void
      */
-    public function finish($finishTime = null, array $logRecords = []);
+    public function finish($finishTime = null);
 
     /**
      * If the span is already finished, a warning should be logged.


### PR DESCRIPTION
Also see #53

This `$logRecords` is not documented by any PHP docs but I imply that implementation suppose to call `log()` before flushing.

Having that means
* `flush()` is responsible for two things
* this feature is specific to this library as it is not found in any other opentracing library

Instead promote usage of

```php
$span->log([...]);
$span->finish();
```