### PR TITLE
Add License Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,3 +276,7 @@ Tracers will throw an exception if the requested format is not handled by them.
 
 OpenTracing PHP follows the [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
 coding standard and the [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md) autoloading standard.
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -279,4 +279,4 @@ coding standard and the [PSR-4](https://github.com/php-fig/fig-standards/blob/ma
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+All the open source contributions are under the terms of the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
License information is added at the bottom of the README.md file along with the link. 



