### PR TITLE
[#60] Changes the API for the In process context propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,23 @@ An example of a linear, two level deep span tree using active spans looks like
 this in PHP code:
 
 ```php
-$root = $tracer->startActiveSpan('php');
+// At dispatcher level
+$scope = $tracer->startActiveSpan('request');
+...
+$scope->close();
+```
+```php
+// At controller level
+$scope = $tracer->startActiveSpan('controller');
+...
+$scope->close();
+```
 
-    $controller = $tracer->startActiveSpan('controller');
-
-        $http = $tracer->startActiveSpan('http');
-        file_get_contents('http://php.net');
-        $http->close();
-
-    $controller->close();
-
-$root->close();
+```php
+// At RPC calls level
+$scope = $tracer->startActiveSpan('http');
+file_get_contents('http://php.net');
+$scope->close();
 ```
 
 #### Creating a child span assigning parent manually
@@ -247,8 +253,8 @@ SpanOptions wrapper object. The following keys are valid:
 - `child_of` is an object of type `OpenTracing\SpanContext` or `OpenTracing\Span`.
 - `references` is an array of `OpenTracing\Reference`.
 - `tags` is an array with string keys and scalar values that represent OpenTracing tags.
-- `finish_span_on_close` is a boolean that determines whether a span should be finished when the
-scope is closed or not.
+- `finish_span_on_close` is a boolean that determines whether a span should be finished or not when the
+scope is closed.
 
 ```php
 $span = $tracer->startActiveSpan('my_span', [

--- a/src/OpenTracing/Exceptions/InvalidSpanOption.php
+++ b/src/OpenTracing/Exceptions/InvalidSpanOption.php
@@ -103,10 +103,10 @@ final class InvalidSpanOption extends InvalidArgumentException
      * @param mixed $value
      * @return InvalidSpanOption
      */
-    public static function forCloseSpanOnFinish($value)
+    public static function forFinishSpanOnClose($value)
     {
         return new self(sprintf(
-            'Invalid type for close_span_on_finish. Expected bool, got %s',
+            'Invalid type for finish_span_on_close. Expected bool, got %s',
             is_object($value) ? get_class($value) : gettype($value)
         ));
     }

--- a/src/OpenTracing/Mock/MockScope.php
+++ b/src/OpenTracing/Mock/MockScope.php
@@ -17,10 +17,24 @@ final class MockScope implements Scope
      */
     private $scopeManager;
 
-    public function __construct(MockScopeManager $scopeManager, Span $span)
-    {
+    /**
+     * @var bool
+     */
+    private $finishSpanOnClose;
+
+    /**
+     * @param MockScopeManager $scopeManager
+     * @param Span $span
+     * @param bool $finishSpanOnClose
+     */
+    public function __construct(
+        MockScopeManager $scopeManager,
+        Span $span,
+        $finishSpanOnClose
+    ) {
         $this->scopeManager = $scopeManager;
         $this->span = $span;
+        $this->finishSpanOnClose = $finishSpanOnClose;
     }
 
     /**
@@ -28,6 +42,10 @@ final class MockScope implements Scope
      */
     public function close()
     {
+        if ($this->finishSpanOnClose) {
+            $this->span->finish();
+        }
+        
         $this->scopeManager->deactivate($this);
     }
 

--- a/src/OpenTracing/Mock/MockScopeManager.php
+++ b/src/OpenTracing/Mock/MockScopeManager.php
@@ -16,9 +16,11 @@ final class MockScopeManager implements ScopeManager
     /**
      * {@inheritdoc}
      */
-    public function activate(Span $span)
+    public function activate(Span $span, $finishSpanOnClose = true)
     {
-        $this->scopes[] = new MockScope($this, $span);
+        $scope = new MockScope($this, $span, $finishSpanOnClose);
+        $this->scopes[] = $scope;
+        return $scope;
     }
 
     /**
@@ -31,23 +33,6 @@ final class MockScopeManager implements ScopeManager
         }
 
         return $this->scopes[count($this->scopes) - 1];
-    }
-
-    /**
-     * {@inheritdoc}
-     * @param Span|MockSpan $span
-     */
-    public function getScope(Span $span)
-    {
-        $scopeLength = count($this->scopes);
-
-        for ($i = 0; $i < $scopeLength; $i++) {
-            if ($span === $this->scopes[$i]->getSpan()) {
-                return $this->scopes[$i];
-            }
-        }
-
-        return null;
     }
 
     public function deactivate(MockScope $scope)

--- a/src/OpenTracing/Mock/MockSpan.php
+++ b/src/OpenTracing/Mock/MockSpan.php
@@ -38,28 +38,14 @@ final class MockSpan implements Span
      */
     private $duration;
 
-    /**
-     * @var bool
-     */
-    private $closeOnFinish;
-
-    /**
-     * @var ScopeManager
-     */
-    private $scopeManager;
-
     public function __construct(
-        ScopeManager $scopeManager,
         $operationName,
         MockSpanContext $context,
-        $startTime = null,
-        $closeOnFinish = false
+        $startTime = null
     ) {
-        $this->scopeManager = $scopeManager;
         $this->operationName = $operationName;
         $this->context = $context;
         $this->startTime = $startTime ?: time();
-        $this->closeOnFinish = $closeOnFinish;
     }
 
     /**
@@ -91,14 +77,6 @@ final class MockSpan implements Span
     {
         $finishTime = ($finishTime ?: time());
         $this->duration = $finishTime - $this->startTime;
-
-        if (!$this->closeOnFinish) {
-            return;
-        }
-
-        if (($scope = $this->scopeManager->getScope($this)) !== null) {
-            $scope->close();
-        }
     }
 
     public function isFinished()

--- a/src/OpenTracing/Mock/MockTracer.php
+++ b/src/OpenTracing/Mock/MockTracer.php
@@ -4,7 +4,7 @@ namespace OpenTracing\Mock;
 
 use OpenTracing\Exceptions\UnsupportedFormat;
 use OpenTracing\ScopeManager;
-use OpenTracing\SpanOptions;
+use OpenTracing\StartSpanOptions;
 use OpenTracing\Tracer;
 use OpenTracing\SpanContext;
 
@@ -42,8 +42,8 @@ final class MockTracer implements Tracer
      */
     public function startActiveSpan($operationName, $options = [])
     {
-        if (!($options instanceof SpanOptions)) {
-            $options = SpanOptions::create($options);
+        if (!($options instanceof StartSpanOptions)) {
+            $options = StartSpanOptions::create($options);
         }
 
         if (($activeSpan = $this->getActiveSpan()) !== null) {
@@ -52,9 +52,7 @@ final class MockTracer implements Tracer
 
         $span = $this->startSpan($operationName, $options);
 
-        $this->scopeManager->activate($span);
-
-        return $span;
+        return $this->scopeManager->activate($span, $options->shouldFinishSpanOnClose());
     }
 
     /**
@@ -62,8 +60,8 @@ final class MockTracer implements Tracer
      */
     public function startSpan($operationName, $options = [])
     {
-        if (!($options instanceof SpanOptions)) {
-            $options = SpanOptions::create($options);
+        if (!($options instanceof StartSpanOptions)) {
+            $options = StartSpanOptions::create($options);
         }
 
         if (empty($options->getReferences())) {
@@ -73,7 +71,6 @@ final class MockTracer implements Tracer
         }
 
         $span = new MockSpan(
-            $this->scopeManager,
             $operationName,
             $spanContext,
             $options->getStartTime()

--- a/src/OpenTracing/NoopScopeManager.php
+++ b/src/OpenTracing/NoopScopeManager.php
@@ -12,7 +12,7 @@ final class NoopScopeManager implements ScopeManager
     /**
      * {@inheritdoc}
      */
-    public function activate(Span $span)
+    public function activate(Span $span, $finishSpanOnClose)
     {
     }
 
@@ -20,14 +20,6 @@ final class NoopScopeManager implements ScopeManager
      * {@inheritdoc}
      */
     public function getActive()
-    {
-        return NoopScope::create();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getScope(Span $span)
     {
         return NoopScope::create();
     }

--- a/src/OpenTracing/NoopTracer.php
+++ b/src/OpenTracing/NoopTracer.php
@@ -38,7 +38,7 @@ final class NoopTracer implements Tracer
     public function startActiveSpan($operationName, $finishSpanOnClose = true, $options = [])
     {
 
-        return NoopSpan::create();
+        return NoopScope::create();
     }
 
     /**

--- a/src/OpenTracing/ScopeManager.php
+++ b/src/OpenTracing/ScopeManager.php
@@ -13,14 +13,12 @@ interface ScopeManager
      * that previous spans can be resumed after a deactivation.
      *
      * @param Span $span the {@link Span} that should become the {@link #active()}
+     * @param bool $finishSpanOnClose whether span should automatically be finished when {@link Scope#close()} is called
      *
-     * Weather the span automatically closes when finish is called depends on
-     * the span options set during the creation of the span. See
-     * {@link SpanOptions#closeSpanOnFinish}
-     *
-     * @return Scope
+     * @return Scope instance to control the end of the active period for the {@link Span}. It is a
+     * programming error to neglect to call {@link Scope#close()} on the returned instance.
      */
-    public function activate(Span $span);
+    public function activate(Span $span, $finishSpanOnClose);
 
     /**
      * Return the currently active {@link Scope} which can be used to access the
@@ -31,16 +29,7 @@ interface ScopeManager
      * newly-created {@link Span} at {@link Tracer.SpanBuilder#startActive(boolean)} or {@link SpanBuilder#start()}
      * time rather than at {@link Tracer#buildSpan(String)} time.
      *
-     * @return \OpenTracing\Scope|null
+     * @return Scope|null
      */
     public function getActive();
-
-    /**
-     * Access the scope of a given Span if available.
-     *
-     * @param Span $span
-     *
-     * @return \OpenTracing\Scope|null
-     */
-    public function getScope(Span $span);
 }

--- a/src/OpenTracing/StartSpanOptions.php
+++ b/src/OpenTracing/StartSpanOptions.php
@@ -5,7 +5,7 @@ namespace OpenTracing;
 use OpenTracing\Exceptions\InvalidReferencesSet;
 use OpenTracing\Exceptions\InvalidSpanOption;
 
-final class SpanOptions
+final class StartSpanOptions
 {
     /**
      * @var Reference[]
@@ -27,13 +27,13 @@ final class SpanOptions
      *
      * @var bool
      */
-    private $closeSpanOnFinish = true;
+    private $finishSpanOnClose = true;
 
     /**
      * @param array $options
      * @throws InvalidSpanOption when one of the options is invalid
      * @throws InvalidReferencesSet when there are inconsistencies about the references
-     * @return SpanOptions
+     * @return StartSpanOptions
      */
     public static function create(array $options)
     {
@@ -86,12 +86,12 @@ final class SpanOptions
                     $spanOptions->startTime = $value;
                     break;
 
-                case 'close_span_on_finish':
+                case 'finish_span_on_close':
                     if (!is_bool($value)) {
-                        throw InvalidSpanOption::forCloseSpanOnFinish($value);
+                        throw InvalidSpanOption::forFinishSpanOnClose($value);
                     }
 
-                    $spanOptions->closeSpanOnFinish = $value;
+                    $spanOptions->finishSpanOnClose = $value;
                     break;
 
                 default:
@@ -105,15 +105,15 @@ final class SpanOptions
 
     /**
      * @param Span|SpanContext $parent
-     * @return SpanOptions
+     * @return StartSpanOptions
      */
     public function withParent($parent)
     {
-        $newSpanOptions = new SpanOptions();
+        $newSpanOptions = new StartSpanOptions();
         $newSpanOptions->references[] = self::buildChildOf($parent);
         $newSpanOptions->tags = $this->tags;
         $newSpanOptions->startTime = $this->startTime;
-        $newSpanOptions->closeSpanOnFinish = $this->closeSpanOnFinish;
+        $newSpanOptions->finishSpanOnClose = $this->finishSpanOnClose;
 
         return $newSpanOptions;
     }
@@ -146,9 +146,9 @@ final class SpanOptions
     /**
      * @return bool
      */
-    public function getCloseSpanOnFinish()
+    public function shouldFinishSpanOnClose()
     {
-        return $this->closeSpanOnFinish;
+        return $this->finishSpanOnClose;
     }
 
     private static function buildChildOf($value)

--- a/src/OpenTracing/Tracer.php
+++ b/src/OpenTracing/Tracer.php
@@ -20,7 +20,7 @@ interface Tracer
      * Tracer::getScopeManager()->getActive()->getSpan(),
      * and null will be returned if {@link Scope#active()} is null.
      *
-     * @return Span|null
+     * @return ScopedSpan|null
      */
     public function getActiveSpan();
 
@@ -48,14 +48,15 @@ interface Tracer
      *  }
      *
      * @param string $operationName
-     * @param array|SpanOptions $options A set of optional parameters:
+     * @param array|StartSpanOptions $options A set of optional parameters:
      *   - Zero or more references to related SpanContexts, including a shorthand for ChildOf and
      *     FollowsFrom reference types if possible.
      *   - An optional explicit start timestamp; if omitted, the current walltime is used by default
      *     The default value should be set by the vendor.
      *   - Zero or more tags
-     *   - CloseSpanOnFinish option which defaults to true.
-     * @return Span
+     *   - FinishSpanOnClose option which defaults to true.
+     *
+     * @return Scope
      */
     public function startActiveSpan($operationName, $options = []);
 
@@ -63,7 +64,7 @@ interface Tracer
      * Starts and returns a new `Span` representing a unit of work.
      *
      * @param string $operationName
-     * @param array|SpanOptions $options
+     * @param array|StartSpanOptions $options
      * @return Span
      * @throws InvalidSpanOption for invalid option
      * @throws InvalidReferencesSet for invalid references set

--- a/src/OpenTracing/Tracer.php
+++ b/src/OpenTracing/Tracer.php
@@ -20,7 +20,7 @@ interface Tracer
      * Tracer::getScopeManager()->getActive()->getSpan(),
      * and null will be returned if {@link Scope#active()} is null.
      *
-     * @return ScopedSpan|null
+     * @return Span|null
      */
     public function getActiveSpan();
 

--- a/tests/OpenTracing/Mock/MockScopeManagerTest.php
+++ b/tests/OpenTracing/Mock/MockScopeManagerTest.php
@@ -28,9 +28,9 @@ final class MockScopeManagerTest extends PHPUnit_Framework_TestCase
     public function testGetScopeReturnsNull()
     {
         $tracer = new MockTracer();
-        $span = $tracer->startSpan(self::OPERATION_NAME);
+        $tracer->startSpan(self::OPERATION_NAME);
         $scopeManager = new MockScopeManager();
-        $this->assertNull($scopeManager->getScope($span));
+        $this->assertNull($scopeManager->getActive());
     }
 
     public function testGetScopeSuccess()
@@ -39,7 +39,7 @@ final class MockScopeManagerTest extends PHPUnit_Framework_TestCase
         $span = $tracer->startSpan(self::OPERATION_NAME);
         $scopeManager = new MockScopeManager();
         $scopeManager->activate($span);
-        $scope = $scopeManager->getScope($span);
+        $scope = $scopeManager->getActive();
         $this->assertSame($span, $scope->getSpan());
     }
 
@@ -49,7 +49,7 @@ final class MockScopeManagerTest extends PHPUnit_Framework_TestCase
         $span = $tracer->startSpan(self::OPERATION_NAME);
         $scopeManager = new MockScopeManager();
         $scopeManager->activate($span);
-        $scope = $scopeManager->getScope($span);
+        $scope = $scopeManager->getActive();
         $scopeManager->deactivate($scope);
         $this->assertNull($scopeManager->getActive());
     }

--- a/tests/OpenTracing/Mock/MockSpanTest.php
+++ b/tests/OpenTracing/Mock/MockSpanTest.php
@@ -22,7 +22,6 @@ final class MockSpanTest extends PHPUnit_Framework_TestCase
     {
         $startTime = time();
         $span = new MockSpan(
-            NoopScopeManager::create(),
             self::OPERATION_NAME,
             MockSpanContext::createAsRoot(),
             $startTime
@@ -35,7 +34,6 @@ final class MockSpanTest extends PHPUnit_Framework_TestCase
     public function testAddTagsAndLogsToSpanSuccess()
     {
         $span = new MockSpan(
-            NoopScopeManager::create(),
             self::OPERATION_NAME,
             MockSpanContext::createAsRoot()
         );
@@ -51,7 +49,6 @@ final class MockSpanTest extends PHPUnit_Framework_TestCase
     {
         $startTime = time();
         $span = new MockSpan(
-            NoopScopeManager::create(),
             self::OPERATION_NAME,
             MockSpanContext::createAsRoot(),
             $startTime

--- a/tests/OpenTracing/Mock/MockTracerTest.php
+++ b/tests/OpenTracing/Mock/MockTracerTest.php
@@ -18,9 +18,9 @@ final class MockTracerTest extends PHPUnit_Framework_TestCase
     public function testStartActiveSpanSuccess()
     {
         $tracer = new MockTracer();
-        $span = $tracer->startActiveSpan(self::OPERATION_NAME);
+        $scope = $tracer->startActiveSpan(self::OPERATION_NAME);
         $activeSpan = $tracer->getActiveSpan();
-        $this->assertEquals($span, $activeSpan);
+        $this->assertEquals($scope->getSpan(), $activeSpan);
     }
 
     public function testStartSpanSuccess()

--- a/tests/OpenTracing/StartSpanOptionsTest.php
+++ b/tests/OpenTracing/StartSpanOptionsTest.php
@@ -4,14 +4,14 @@ namespace OpenTracing\Tests;
 
 use OpenTracing\Exceptions\InvalidSpanOption;
 use OpenTracing\NoopSpanContext;
-use OpenTracing\SpanOptions;
+use OpenTracing\StartSpanOptions;
 use OpenTracing\Reference;
 use PHPUnit_Framework_TestCase;
 
 /**
- * @covers SpanOptions
+ * @covers StartSpanOptions
  */
-final class SpanOptionsTest extends PHPUnit_Framework_TestCase
+final class StartSpanOptionsTest extends PHPUnit_Framework_TestCase
 {
     const REFERENCE_TYPE = 'a_reference_type';
 
@@ -19,7 +19,7 @@ final class SpanOptionsTest extends PHPUnit_Framework_TestCase
     {
         $this->expectException(InvalidSpanOption::class);
 
-        SpanOptions::create([
+        StartSpanOptions::create([
             'unknown_option' => 'value'
         ]);
     }
@@ -28,8 +28,8 @@ final class SpanOptionsTest extends PHPUnit_Framework_TestCase
     {
         $this->expectException(InvalidSpanOption::class);
 
-        SpanOptions::create([
-            'close_span_on_finish' => 'value'
+        StartSpanOptions::create([
+            'finish_span_on_close' => 'value'
         ]);
     }
 
@@ -37,7 +37,7 @@ final class SpanOptionsTest extends PHPUnit_Framework_TestCase
     {
         $this->expectException(InvalidSpanOption::class);
 
-        SpanOptions::create([
+        StartSpanOptions::create([
             'start_time' => 'abc'
         ]);
     }
@@ -45,7 +45,7 @@ final class SpanOptionsTest extends PHPUnit_Framework_TestCase
     /** @dataProvider validStartTime */
     public function testSpanOptionsCanBeCreatedBecauseWithValidStartTime($startTime)
     {
-        $spanOptions = SpanOptions::create([
+        $spanOptions = StartSpanOptions::create([
             'start_time' => $startTime
         ]);
 
@@ -70,7 +70,7 @@ final class SpanOptionsTest extends PHPUnit_Framework_TestCase
             'references' => Reference::create(self::REFERENCE_TYPE, $context),
         ];
 
-        $spanOptions = SpanOptions::create($options);
+        $spanOptions = StartSpanOptions::create($options);
         $references = $spanOptions->getReferences()[0];
 
         $this->assertTrue($references->isType(self::REFERENCE_TYPE));
@@ -79,24 +79,24 @@ final class SpanOptionsTest extends PHPUnit_Framework_TestCase
 
     public function testSpanOptionsDefaultCloseOnFinishValue()
     {
-        $options = SpanOptions::create([]);
+        $options = StartSpanOptions::create([]);
 
-        $this->assertTrue($options->getCloseSpanOnFinish());
+        $this->assertTrue($options->shouldFinishSpanOnClose());
     }
 
-    public function testSpanOptionsWithValidCloseOnFinishValue()
+    public function testSpanOptionsWithValidFinishSpanOnClose()
     {
-        $options = SpanOptions::create([
-            'close_span_on_finish' => false,
+        $options = StartSpanOptions::create([
+            'finish_span_on_close' => false,
         ]);
 
-        $this->assertFalse($options->getCloseSpanOnFinish());
+        $this->assertFalse($options->shouldFinishSpanOnClose());
     }
 
     public function testSpanOptionsAddsANewReference()
     {
         $context1 = NoopSpanContext::create();
-        $spanOptions = SpanOptions::create([
+        $spanOptions = StartSpanOptions::create([
             'child_of' => $context1,
         ]);
         $this->assertCount(1, $spanOptions->getReferences());


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

Please don't open huge pull requests and keep one pull request solving one problem.

Please enter the issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->

Read #61 for more context

### Short description of what this PR does:
- Changes the `Tracer::startActiveSpan` signature to return a scope.
- Changes the `ScopeManager` to not to be aware of spans

This is a breaking change but since we are still in beta, it is OK.

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

Fixes #61

Ping @beberlei @yurishkuro @ellisv @tedsuo 