### PR TITLE
Allow method chaining for Span

### DIFF
--- a/src/OpenTracing/Mock/MockSpan.php
+++ b/src/OpenTracing/Mock/MockSpan.php
@@ -95,6 +95,8 @@ final class MockSpan implements Span
     public function overwriteOperationName($newOperationName)
     {
         $this->operationName = (string) $newOperationName;
+
+        return $this;
     }
 
     /**
@@ -103,6 +105,8 @@ final class MockSpan implements Span
     public function setTag($key, $value)
     {
         $this->tags[$key] = $value;
+
+        return $this;
     }
 
     public function getTags()
@@ -119,6 +123,8 @@ final class MockSpan implements Span
             'timestamp' => $timestamp ?: time(),
             'fields' => $fields,
         ];
+
+        return $this;
     }
 
     public function getLogs()
@@ -132,6 +138,8 @@ final class MockSpan implements Span
     public function addBaggageItem($key, $value)
     {
         $this->context = $this->context->withBaggageItem($key, $value);
+
+        return $this;
     }
 
     /**

--- a/src/OpenTracing/NoopSpan.php
+++ b/src/OpenTracing/NoopSpan.php
@@ -37,6 +37,7 @@ final class NoopSpan implements Span
      */
     public function overwriteOperationName($newOperationName)
     {
+        return $this;
     }
 
     /**
@@ -44,6 +45,7 @@ final class NoopSpan implements Span
      */
     public function setTag($key, $value)
     {
+        return $this;
     }
 
     /**
@@ -51,6 +53,7 @@ final class NoopSpan implements Span
      */
     public function log(array $fields = [], $timestamp = null)
     {
+        return $this;
     }
 
     /**
@@ -58,6 +61,7 @@ final class NoopSpan implements Span
      */
     public function addBaggageItem($key, $value)
     {
+        return $this;
     }
 
     /**

--- a/src/OpenTracing/Span.php
+++ b/src/OpenTracing/Span.php
@@ -40,6 +40,7 @@ interface Span
      * If the span is already finished, a warning should be logged.
      *
      * @param string $newOperationName
+     * @return $this
      */
     public function overwriteOperationName($newOperationName);
 
@@ -54,7 +55,7 @@ interface Span
      *
      * @param string $key
      * @param string|bool|int|float $value
-     * @return void
+     * @return $this
      */
     public function setTag($key, $value);
 
@@ -66,7 +67,7 @@ interface Span
      *
      * @param array $fields
      * @param int|float|\DateTimeInterface $timestamp
-     * @return void
+     * @return $this
      */
     public function log(array $fields = [], $timestamp = null);
 
@@ -78,7 +79,7 @@ interface Span
      *
      * @param string $key
      * @param string $value
-     * @return void
+     * @return $this
      */
     public function addBaggageItem($key, $value);
 


### PR DESCRIPTION
This allows the usage of

```php
$span
    ->log([...])
    ->setTag(Tags\ERROR, true);
```

This behavior is also found in other OpenTracing libraries.