### PR TITLE
[#63] Adds default value for finish_span_on_close in scope manager activation

### DIFF
--- a/src/OpenTracing/Mock/MockScopeManager.php
+++ b/src/OpenTracing/Mock/MockScopeManager.php
@@ -16,7 +16,7 @@ final class MockScopeManager implements ScopeManager
     /**
      * {@inheritdoc}
      */
-    public function activate(Span $span, $finishSpanOnClose = true)
+    public function activate(Span $span, $finishSpanOnClose = ScopeManager::DEFAULT_FINISH_SPAN_ON_CLOSE)
     {
         $scope = new MockScope($this, $span, $finishSpanOnClose);
         $this->scopes[] = $scope;

--- a/src/OpenTracing/NoopScopeManager.php
+++ b/src/OpenTracing/NoopScopeManager.php
@@ -12,7 +12,7 @@ final class NoopScopeManager implements ScopeManager
     /**
      * {@inheritdoc}
      */
-    public function activate(Span $span, $finishSpanOnClose)
+    public function activate(Span $span, $finishSpanOnClose = ScopeManager::DEFAULT_FINISH_SPAN_ON_CLOSE)
     {
     }
 

--- a/src/OpenTracing/ScopeManager.php
+++ b/src/OpenTracing/ScopeManager.php
@@ -7,18 +7,21 @@ namespace OpenTracing;
  */
 interface ScopeManager
 {
+    const DEFAULT_FINISH_SPAN_ON_CLOSE = true;
+
     /**
      * Activates an `Span`, so that it is used as a parent when creating new spans.
      * The implementation must keep track of the active spans sequence, so
      * that previous spans can be resumed after a deactivation.
      *
      * @param Span $span the {@link Span} that should become the {@link #active()}
-     * @param bool $finishSpanOnClose whether span should automatically be finished when {@link Scope#close()} is called
+     * @param bool $finishSpanOnClose whether span should automatically be finished
+     * when {@link Scope#close()} is called. Its default value is true.
      *
      * @return Scope instance to control the end of the active period for the {@link Span}. It is a
      * programming error to neglect to call {@link Scope#close()} on the returned instance.
      */
-    public function activate(Span $span, $finishSpanOnClose);
+    public function activate(Span $span, $finishSpanOnClose = self::DEFAULT_FINISH_SPAN_ON_CLOSE);
 
     /**
      * Return the currently active {@link Scope} which can be used to access the

--- a/src/OpenTracing/StartSpanOptions.php
+++ b/src/OpenTracing/StartSpanOptions.php
@@ -27,7 +27,7 @@ final class StartSpanOptions
      *
      * @var bool
      */
-    private $finishSpanOnClose = true;
+    private $finishSpanOnClose = ScopeManager::DEFAULT_FINISH_SPAN_ON_CLOSE;
 
     /**
      * @param array $options


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

Please don't open huge pull requests and keep one pull request solving one problem.

Please enter the issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->

### Short description of what this PR does:
- Adds a default value for `$finishSpanOnClose` in `ScopeManager::activate`.

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added in line documentation to the code I modified

Closes #63