### PR TITLE
Remove static factories that match constructor

### DIFF
--- a/src/OpenTracing/Mock/MockSpanContext.php
+++ b/src/OpenTracing/Mock/MockSpanContext.php
@@ -27,17 +27,12 @@ final class MockSpanContext implements SpanContext
      */
     private $items;
 
-    private function __construct($traceId, $spanId, $isSampled, array $items)
+    public function __construct($traceId, $spanId, $isSampled = true, array $items = [])
     {
         $this->traceId = $traceId;
         $this->spanId = $spanId;
         $this->isSampled = $isSampled;
         $this->items = $items;
-    }
-
-    public static function create($traceId, $spanId, $sampled = true, array $items = [])
-    {
-        return new self($traceId, $spanId, $sampled, $items);
     }
 
     public static function createAsRoot($sampled = true, array $items = [])

--- a/src/OpenTracing/Mock/MockTracer.php
+++ b/src/OpenTracing/Mock/MockTracer.php
@@ -43,7 +43,7 @@ final class MockTracer implements Tracer
     public function startActiveSpan($operationName, $options = [])
     {
         if (!($options instanceof StartSpanOptions)) {
-            $options = StartSpanOptions::create($options);
+            $options = new StartSpanOptions($options);
         }
 
         if (($activeSpan = $this->getActiveSpan()) !== null) {
@@ -61,7 +61,7 @@ final class MockTracer implements Tracer
     public function startSpan($operationName, $options = [])
     {
         if (!($options instanceof StartSpanOptions)) {
-            $options = StartSpanOptions::create($options);
+            $options = new StartSpanOptions($options);
         }
 
         if (empty($options->getReferences())) {

--- a/src/OpenTracing/NoopScope.php
+++ b/src/OpenTracing/NoopScope.php
@@ -4,11 +4,6 @@ namespace OpenTracing;
 
 final class NoopScope implements Scope
 {
-    public static function create()
-    {
-        return new self();
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -21,6 +16,6 @@ final class NoopScope implements Scope
      */
     public function getSpan()
     {
-        return NoopSpan::create();
+        return new NoopSpan();
     }
 }

--- a/src/OpenTracing/NoopScopeManager.php
+++ b/src/OpenTracing/NoopScopeManager.php
@@ -4,11 +4,6 @@ namespace OpenTracing;
 
 final class NoopScopeManager implements ScopeManager
 {
-    public static function create()
-    {
-        return new self();
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -21,6 +16,6 @@ final class NoopScopeManager implements ScopeManager
      */
     public function getActive()
     {
-        return NoopScope::create();
+        return new NoopScope();
     }
 }

--- a/src/OpenTracing/NoopSpan.php
+++ b/src/OpenTracing/NoopSpan.php
@@ -4,11 +4,6 @@ namespace OpenTracing;
 
 final class NoopSpan implements Span
 {
-    public static function create()
-    {
-        return new self();
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -22,7 +17,7 @@ final class NoopSpan implements Span
      */
     public function getContext()
     {
-        return NoopSpanContext::create();
+        return new NoopSpanContext();
     }
 
     /**

--- a/src/OpenTracing/NoopSpanContext.php
+++ b/src/OpenTracing/NoopSpanContext.php
@@ -6,11 +6,6 @@ use EmptyIterator;
 
 final class NoopSpanContext implements SpanContext
 {
-    public static function create()
-    {
-        return new self();
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/OpenTracing/NoopTracer.php
+++ b/src/OpenTracing/NoopTracer.php
@@ -9,7 +9,7 @@ final class NoopTracer implements Tracer
      */
     public function getActiveSpan()
     {
-        return NoopSpan::create();
+        return new NoopSpan();
     }
 
     /**
@@ -38,7 +38,7 @@ final class NoopTracer implements Tracer
     public function startActiveSpan($operationName, $finishSpanOnClose = true, $options = [])
     {
 
-        return NoopScope::create();
+        return new NoopScope();
     }
 
     /**
@@ -53,7 +53,7 @@ final class NoopTracer implements Tracer
      */
     public function extract($format, $carrier)
     {
-        return NoopSpanContext::create();
+        return new NoopSpanContext();
     }
 
     /**

--- a/src/OpenTracing/Reference.php
+++ b/src/OpenTracing/Reference.php
@@ -31,27 +31,16 @@ final class Reference
 
     /**
      * @param string $type
-     * @param SpanContext $context
-     */
-    private function __construct($type, SpanContext $context)
-    {
-        $this->type = $type;
-        $this->context = $context;
-    }
-
-    /**
      * @param SpanContext|Span $context
-     * @param string $type
-     * @throws InvalidReferenceArgument on empty type
-     * @return Reference when context is invalid
      */
-    public static function create($type, $context)
+    public function __construct($type, $context)
     {
         if (empty($type)) {
             throw InvalidReferenceArgument::forEmptyType();
         }
 
-        return new self($type, self::extractContext($context));
+        $this->type = $type;
+        $this->context = self::extractContext($context);
     }
 
     /**

--- a/tests/OpenTracing/Mock/MockSpanContextTest.php
+++ b/tests/OpenTracing/Mock/MockSpanContextTest.php
@@ -22,7 +22,7 @@ final class MockSpanContextTest extends PHPUnit_Framework_TestCase
 
     public function testCreateMockSpanContextSuccess()
     {
-        $spanContext = MockSpanContext::create(
+        $spanContext = new MockSpanContext(
             self::TRACE_ID,
             self::SPAN_ID,
             self::IS_SAMPLED,
@@ -38,7 +38,7 @@ final class MockSpanContextTest extends PHPUnit_Framework_TestCase
 
     public function testAddBaggageItemSuccess()
     {
-        $spanContext = MockSpanContext::create(
+        $spanContext = new MockSpanContext(
             self::TRACE_ID,
             self::SPAN_ID,
             self::IS_SAMPLED

--- a/tests/OpenTracing/Mock/MockTracerTest.php
+++ b/tests/OpenTracing/Mock/MockTracerTest.php
@@ -74,7 +74,7 @@ final class MockTracerTest extends PHPUnit_Framework_TestCase
 
         $extractor = function ($carrier) use (&$actualCarrier) {
             $actualCarrier = $carrier;
-            return NoopSpan::create();
+            return new NoopSpan();
         };
 
         $tracer = new MockTracer([], [self::FORMAT => $extractor]);

--- a/tests/OpenTracing/ReferenceTest.php
+++ b/tests/OpenTracing/ReferenceTest.php
@@ -21,7 +21,7 @@ final class ReferenceTest extends PHPUnit_Framework_TestCase
         $this->expectExceptionMessage(
             'Reference expects \OpenTracing\Span or \OpenTracing\SpanContext as context, got string'
         );
-        Reference::create('child_of', $context);
+        new Reference('child_of', $context);
     }
 
     public function testCreateAReferenceFailsOnEmptyType()
@@ -29,13 +29,13 @@ final class ReferenceTest extends PHPUnit_Framework_TestCase
         $context = new NoopSpanContext();
         $this->expectException(InvalidReferenceArgument::class);
         $this->expectExceptionMessage('Reference type can not be an empty string');
-        Reference::create('', $context);
+        new Reference('', $context);
     }
 
     public function testAReferenceCanBeCreatedAsACustomType()
     {
         $context = new NoopSpanContext();
-        $reference = Reference::create(self::REFERENCE_TYPE, $context);
+        $reference = new Reference(self::REFERENCE_TYPE, $context);
         $this->assertSame($context, $reference->getContext());
         $this->assertTrue($reference->isType(self::REFERENCE_TYPE));
     }

--- a/tests/OpenTracing/StartSpanOptionsTest.php
+++ b/tests/OpenTracing/StartSpanOptionsTest.php
@@ -19,7 +19,7 @@ final class StartSpanOptionsTest extends PHPUnit_Framework_TestCase
     {
         $this->expectException(InvalidSpanOption::class);
 
-        StartSpanOptions::create([
+        new StartSpanOptions([
             'unknown_option' => 'value'
         ]);
     }
@@ -28,7 +28,7 @@ final class StartSpanOptionsTest extends PHPUnit_Framework_TestCase
     {
         $this->expectException(InvalidSpanOption::class);
 
-        StartSpanOptions::create([
+        new StartSpanOptions([
             'finish_span_on_close' => 'value'
         ]);
     }
@@ -37,7 +37,7 @@ final class StartSpanOptionsTest extends PHPUnit_Framework_TestCase
     {
         $this->expectException(InvalidSpanOption::class);
 
-        StartSpanOptions::create([
+        new StartSpanOptions([
             'start_time' => 'abc'
         ]);
     }
@@ -45,7 +45,7 @@ final class StartSpanOptionsTest extends PHPUnit_Framework_TestCase
     /** @dataProvider validStartTime */
     public function testSpanOptionsCanBeCreatedBecauseWithValidStartTime($startTime)
     {
-        $spanOptions = StartSpanOptions::create([
+        $spanOptions = new StartSpanOptions([
             'start_time' => $startTime
         ]);
 
@@ -64,13 +64,13 @@ final class StartSpanOptionsTest extends PHPUnit_Framework_TestCase
 
     public function testSpanOptionsCanBeCreatedWithValidReference()
     {
-        $context = NoopSpanContext::create();
+        $context = new NoopSpanContext();
 
         $options = [
-            'references' => Reference::create(self::REFERENCE_TYPE, $context),
+            'references' => new Reference(self::REFERENCE_TYPE, $context),
         ];
 
-        $spanOptions = StartSpanOptions::create($options);
+        $spanOptions = new StartSpanOptions($options);
         $references = $spanOptions->getReferences()[0];
 
         $this->assertTrue($references->isType(self::REFERENCE_TYPE));
@@ -79,14 +79,14 @@ final class StartSpanOptionsTest extends PHPUnit_Framework_TestCase
 
     public function testSpanOptionsDefaultCloseOnFinishValue()
     {
-        $options = StartSpanOptions::create([]);
+        $options = new StartSpanOptions([]);
 
         $this->assertTrue($options->shouldFinishSpanOnClose());
     }
 
     public function testSpanOptionsWithValidFinishSpanOnClose()
     {
-        $options = StartSpanOptions::create([
+        $options = new StartSpanOptions([
             'finish_span_on_close' => false,
         ]);
 
@@ -95,13 +95,13 @@ final class StartSpanOptionsTest extends PHPUnit_Framework_TestCase
 
     public function testSpanOptionsAddsANewReference()
     {
-        $context1 = NoopSpanContext::create();
-        $spanOptions = StartSpanOptions::create([
+        $context1 = new NoopSpanContext();
+        $spanOptions = new StartSpanOptions([
             'child_of' => $context1,
         ]);
         $this->assertCount(1, $spanOptions->getReferences());
 
-        $context2 = NoopSpanContext::create();
+        $context2 = new NoopSpanContext();
         $spanOptions = $spanOptions->withParent($context2);
         $this->assertCount(1, $spanOptions->getReferences());
         $this->assertSame($context2, $spanOptions->getReferences()[0]->getContext());
@@ -109,14 +109,14 @@ final class StartSpanOptionsTest extends PHPUnit_Framework_TestCase
 
     public function testDefaultIgnoreActiveSpan()
     {
-        $options = StartSpanOptions::create([]);
+        $options = new StartSpanOptions([]);
 
         $this->assertFalse($options->shouldIgnoreActiveSpan());
     }
 
     public function testSpanOptionsWithValidIgnoreActiveSpan()
     {
-        $options = StartSpanOptions::create([
+        $options = new StartSpanOptions([
             'ignore_active_span' => true,
         ]);
 


### PR DESCRIPTION
This is to launch a discussion. So a question is whenever there is a reason for having static factories that match a constructor? There is a perfectly fine built in language syntax for creating objects and by introducing static factories we are giving users to doubt if to go with static factory or a `new` construct.