### PR TITLE
Introduce ignore_active_span option

### DIFF
--- a/src/OpenTracing/Exceptions/InvalidSpanOption.php
+++ b/src/OpenTracing/Exceptions/InvalidSpanOption.php
@@ -110,4 +110,16 @@ final class InvalidSpanOption extends InvalidArgumentException
             is_object($value) ? get_class($value) : gettype($value)
         ));
     }
+
+    /**
+     * @param mixed $value
+     * @return InvalidSpanOption
+     */
+    public static function forIgnoreActiveSpan($value)
+    {
+        return new self(sprintf(
+            'Invalid type for ignore_active_span. Expected bool, got %s',
+            is_object($value) ? get_class($value) : gettype($value)
+        ));
+    }
 }

--- a/src/OpenTracing/StartSpanOptions.php
+++ b/src/OpenTracing/StartSpanOptions.php
@@ -30,6 +30,11 @@ final class StartSpanOptions
     private $finishSpanOnClose = ScopeManager::DEFAULT_FINISH_SPAN_ON_CLOSE;
 
     /**
+     * @var bool
+     */
+    private $ignoreActiveSpan = false;
+
+    /**
      * @param array $options
      * @throws InvalidSpanOption when one of the options is invalid
      * @throws InvalidReferencesSet when there are inconsistencies about the references
@@ -94,6 +99,14 @@ final class StartSpanOptions
                     $spanOptions->finishSpanOnClose = $value;
                     break;
 
+                case 'ignore_active_span':
+                    if (!is_bool($value)) {
+                        throw InvalidSpanOption::forIgnoreActiveSpan($value);
+                    }
+
+                    $spanOptions->ignoreActiveSpan = $value;
+                    break;
+
                 default:
                     throw InvalidSpanOption::forUnknownOption($key);
                     break;
@@ -114,6 +127,7 @@ final class StartSpanOptions
         $newSpanOptions->tags = $this->tags;
         $newSpanOptions->startTime = $this->startTime;
         $newSpanOptions->finishSpanOnClose = $this->finishSpanOnClose;
+        $newSpanOptions->ignoreActiveSpan = $this->ignoreActiveSpan;
 
         return $newSpanOptions;
     }
@@ -149,6 +163,14 @@ final class StartSpanOptions
     public function shouldFinishSpanOnClose()
     {
         return $this->finishSpanOnClose;
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldIgnoreActiveSpan()
+    {
+        return $this->ignoreActiveSpan;
     }
 
     private static function buildChildOf($value)

--- a/src/OpenTracing/Tracer.php
+++ b/src/OpenTracing/Tracer.php
@@ -55,6 +55,7 @@ interface Tracer
      *     The default value should be set by the vendor.
      *   - Zero or more tags
      *   - FinishSpanOnClose option which defaults to true.
+     *   - IgnoreActiveSpan option which defaults to false.
      *
      * @return Scope
      */

--- a/tests/OpenTracing/StartSpanOptionsTest.php
+++ b/tests/OpenTracing/StartSpanOptionsTest.php
@@ -106,4 +106,20 @@ final class StartSpanOptionsTest extends PHPUnit_Framework_TestCase
         $this->assertCount(1, $spanOptions->getReferences());
         $this->assertSame($context2, $spanOptions->getReferences()[0]->getContext());
     }
+
+    public function testDefaultIgnoreActiveSpan()
+    {
+        $options = StartSpanOptions::create([]);
+
+        $this->assertFalse($options->shouldIgnoreActiveSpan());
+    }
+
+    public function testSpanOptionsWithValidIgnoreActiveSpan()
+    {
+        $options = StartSpanOptions::create([
+            'ignore_active_span' => true,
+        ]);
+
+        $this->assertTrue($options->shouldIgnoreActiveSpan());
+    }
 }


### PR DESCRIPTION
Both `Tracer::startSpan()` and `Tracer::startActiveSpan()` in implementation should start a new span as child of active span unless ignore_active_span option is set to true.