### PR TITLE
Update phpdoc for Tracer::startActiveSpan() and Tracer::startSpan()

### DIFF
--- a/src/OpenTracing/Tracer.php
+++ b/src/OpenTracing/Tracer.php
@@ -45,7 +45,7 @@ interface Tracer
      *
      * @param string $operationName
      * @param array|StartSpanOptions $options Same as for startSpan() with
-     *     aditional option of `close_span_on_finish` that enables finishing
+     *     aditional option of `finish_span_on_close` that enables finishing
      *     of span whenever a scope is closed. It is true by default.
      *
      * @return Scope A Scope that holds newly created Span and is activated on


### PR DESCRIPTION
Change a phpdoc by adjusting that `startActive()` also must use `ScopeManager::getActive()` span whenever ignore_active_span is false and child_of is not explicitly set.

Changed phpdoc is also validated against phpdoc.org generator.