### PR TITLE
Fix: Composer resolves binaries itself

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         }
     },
     "scripts": {
-        "test": "./vendor/bin/phpunit tests",
-        "lint": "./vendor/bin/phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
-        "fix-lint": "./vendor/bin/phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./"
+        "test": "phpunit tests",
+        "lint": "phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
+        "fix-lint": "phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./"
     }
 }


### PR DESCRIPTION
### Short description of what this PR does:

* [x] removes unnecessary prefixes to vendor binaries in `composer.json`

💁‍♂️ For reference, see https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands:

>**Note**: Before executing scripts, Composer's bin-dir is temporarily pushed on top of the PATH environment variable so that binaries of dependencies are easily accessible. In this example no matter if the `phpunit` binary is actually in `vendor/bin/phpunit` or `bin/phpunit` it will be found and executed.

Follows https://github.com/opentracing/opentracing-php/pull/65#discussion_r202249213.

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified
