### PR TITLE
Don't throw exception on Tracer::inject/extract

### DIFF
--- a/src/OpenTracing/Tracer.php
+++ b/src/OpenTracing/Tracer.php
@@ -4,7 +4,6 @@ namespace OpenTracing;
 
 use OpenTracing\Exceptions\InvalidReferencesSet;
 use OpenTracing\Exceptions\InvalidSpanOption;
-use OpenTracing\Exceptions\UnsupportedFormat;
 
 interface Tracer
 {
@@ -45,7 +44,7 @@ interface Tracer
      *
      * @param string $operationName
      * @param array|StartSpanOptions $options Same as for startSpan() with
-     *     aditional option of `finish_span_on_close` that enables finishing
+     *     additional option of `finish_span_on_close` that enables finishing
      *     of span whenever a scope is closed. It is true by default.
      *
      * @return Scope A Scope that holds newly created Span and is activated on
@@ -81,26 +80,28 @@ interface Tracer
     public function startSpan($operationName, $options = []);
 
     /**
+     * All exceptions thrown from this method should be caught and logged on WARN level so
+     * that business code execution isn't affected. If possible, catch implementation specific
+     * exceptions and log more meaningful information.
+     *
      * @param SpanContext $spanContext
      * @param string $format
      * @param mixed $carrier
      *
      * @see Formats
-     *
-     * @throws UnsupportedFormat when the format is not recognized by the tracer
-     * implementation
      */
     public function inject(SpanContext $spanContext, $format, &$carrier);
 
     /**
+     * All exceptions thrown from this method should be caught and logged on WARN level so
+     * that business code execution isn't affected. If possible, catch implementation specific
+     * exceptions and log more meaningful information.
+     *
      * @param string $format
      * @param mixed $carrier
      * @return SpanContext|null
      *
      * @see Formats
-     *
-     * @throws UnsupportedFormat when the format is not recognized by the tracer
-     * implementation
      */
     public function extract($format, $carrier);
 


### PR DESCRIPTION
### Short description of what this PR does:
- Don't throw exception on `Tracer::inject` and `Tracer::extract`

All exceptions thrown from `Tracer::inject` and `Tracer::extract` should be caught and logged on WARN level so that business code execution isn't affected. If possible, catch implementation specific exceptions and log more meaningful information.

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified