### PR TITLE
FIX Invalid return for NoopTracer::startSpan

### DIFF
--- a/src/OpenTracing/NoopTracer.php
+++ b/src/OpenTracing/NoopTracer.php
@@ -30,6 +30,7 @@ final class NoopTracer implements Tracer
      */
     public function startSpan($operationName, $options = [])
     {
+        return NoopSpan::create();
     }
 
     /**


### PR DESCRIPTION
### Short description of what this PR does:

NoopTracer::startSpan was returning null instead of Span

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified
