### PR TITLE
fix: remove obsolete attribute from config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
         forceCoversAnnotation="false"
-        mapTestClassNameToCoveredClassName="false"
         printerClass="PHPUnit\TextUI\ResultPrinter"
         processIsolation="false"
         stopOnError="false"


### PR DESCRIPTION

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

Please don't open huge pull requests and keep one pull request solving one problem.

Please enter the issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->

According to sebastianbergmann/php-code-coverage#397 and sebastianbergmann/phpunit-documentation-english#91, the feature is obsolete. Therefore, I removed `mapTestClassNameToCoveredClassName` from the phpunit configuration file.
