### PR TITLE
chore: add PHP 7.4 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
 
 cache:
   directories:


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

Please don't open huge pull requests and keep one pull request solving one problem.

Please enter the issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->

As [PHP 7.4 is released](https://www.php.net/releases/7_4_0.php) since November 2019, we should add it to the Travis build matrix.