### PR TITLE
Upgrade interfaces from php56

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ install:
 
 script:
   - composer lint
+  - composer static-check
   - composer test

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "php": "^7.1"
   },
   "require-dev": {
+    "phpstan/phpstan": "~0.12",
     "phpunit/phpunit": "~7.5.8",
     "squizlabs/php_codesniffer": "3.*"
   },
@@ -37,6 +38,7 @@
   "scripts": {
     "fix-lint": "phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
     "lint": "phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
-    "test": "phpunit tests"
+    "test": "phpunit tests",
+    "static-check": "phpstan analyse src --level 4"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,6 @@
     "fix-lint": "phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
     "lint": "phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
     "test": "phpunit tests",
-    "static-check": "phpstan analyse src --level 4"
+    "static-check": "phpstan analyse"
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,4 @@ parameters:
     - src
 
   level: 4
+  treatPhpDocTypesAsCertain: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+  paths:
+    - src
+
+  level: 4

--- a/src/OpenTracing/Mock/MockSpan.php
+++ b/src/OpenTracing/Mock/MockSpan.php
@@ -13,7 +13,7 @@ final class MockSpan implements Span
     private $operationName;
 
     /**
-     * @var MockSpanContext
+     * @var SpanContext
      */
     private $context;
 

--- a/src/OpenTracing/Reference.php
+++ b/src/OpenTracing/Reference.php
@@ -45,7 +45,7 @@ final class Reference
      * @return Reference when context is invalid
      * @throws InvalidReferenceArgument on empty type
      */
-    public static function create(string $type, $context)
+    public static function create(string $type, $context): Reference
     {
         if (empty($type)) {
             throw InvalidReferenceArgument::forEmptyType();

--- a/src/OpenTracing/StartSpanOptions.php
+++ b/src/OpenTracing/StartSpanOptions.php
@@ -111,7 +111,6 @@ final class StartSpanOptions
 
                 default:
                     throw InvalidSpanOption::forUnknownOption($key);
-                    break;
             }
         }
 


### PR DESCRIPTION
### Short description of what this PR does:
- ensures interfaces are 7.1 compatible
- adds phpstan/phpstan to travis
- fixes 3 phpstan issues

Closes #94 

*Hint*:
I had to disable the `treatPhpDocTypesAsCertain` option for phpstan, otherwise it would complain about [an unreachable code block in Reference.php](https://github.com/opentracing/opentracing-php/blob/be33b2963dbe28ec365e33efe0b291e52ae47913/src/OpenTracing/Reference.php#L91).