### PR TITLE
fix MockSpan creation

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,5 @@ parameters:
   paths:
     - src
 
-  level: 4
+  level: 5
   treatPhpDocTypesAsCertain: false

--- a/src/OpenTracing/Mock/MockSpan.php
+++ b/src/OpenTracing/Mock/MockSpan.php
@@ -39,7 +39,7 @@ final class MockSpan implements Span
 
     public function __construct(
         string $operationName,
-        MockSpanContext $context,
+        SpanContext $context,
         ?int $startTime = null
     ) {
         $this->operationName = $operationName;

--- a/src/OpenTracing/Mock/MockTracer.php
+++ b/src/OpenTracing/Mock/MockTracer.php
@@ -2,6 +2,7 @@
 
 namespace OpenTracing\Mock;
 
+use OpenTracing\Exceptions\InvalidReferenceArgument;
 use OpenTracing\Exceptions\UnsupportedFormat;
 use OpenTracing\Scope;
 use OpenTracing\ScopeManager;
@@ -69,7 +70,11 @@ final class MockTracer implements Tracer
         if (empty($options->getReferences())) {
             $spanContext = MockSpanContext::createAsRoot();
         } else {
-            $spanContext = MockSpanContext::createAsChildOf($options->getReferences()[0]);
+            $referenceContext = $options->getReferences()[0]->getContext();
+            if (!$referenceContext instanceof MockSpanContext) {
+                throw InvalidReferenceArgument::forInvalidContext($referenceContext);
+            }
+            $spanContext = MockSpanContext::createAsChildOf($referenceContext);
         }
 
         $span = new MockSpan($operationName, $spanContext, $options->getStartTime());

--- a/tests/OpenTracing/Mock/MockTracerTest.php
+++ b/tests/OpenTracing/Mock/MockTracerTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace OpenTracing\Mock\Tests;
+namespace OpenTracing\Tests\Mock;
 
 use OpenTracing\Exceptions\UnsupportedFormat;
 use OpenTracing\Mock\MockTracer;
 use OpenTracing\NoopSpanContext;
+use OpenTracing\Reference;
 use OpenTracing\SpanContext;
 use PHPUnit\Framework\TestCase;
 
@@ -32,6 +33,20 @@ final class MockTracerTest extends TestCase
         $activeSpan = $tracer->getActiveSpan();
 
         $this->assertNull($activeSpan);
+    }
+
+    public function testStartSpanWithReference(): void
+    {
+        $tracer = new MockTracer();
+        $tracer->startSpan('parent_name');
+        $parentSpan = $tracer->getSpans()[0];
+        $tracer->startSpan(
+            self::OPERATION_NAME,
+            ['references' => [Reference::create(Reference::CHILD_OF, $parentSpan)]]
+        );
+        $activeSpan = $tracer->getActiveSpan();
+
+        self::assertNull($activeSpan);
     }
 
     public function testInjectWithNoInjectorsFails()

--- a/tests/OpenTracing/Mock/MockTracerTest.php
+++ b/tests/OpenTracing/Mock/MockTracerTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenTracing\Tests\Mock;
 
+use OpenTracing\Exceptions\InvalidReferenceArgument;
 use OpenTracing\Exceptions\UnsupportedFormat;
 use OpenTracing\Mock\MockTracer;
 use OpenTracing\NoopSpanContext;
@@ -47,6 +48,19 @@ final class MockTracerTest extends TestCase
         $activeSpan = $tracer->getActiveSpan();
 
         self::assertNull($activeSpan);
+    }
+
+    public function testStartSpanWithReferenceWithoutExpectedContextType(): void
+    {
+        $tracer = new MockTracer();
+        $notAMockContext = NoopSpanContext::create();
+
+        $this->expectException(InvalidReferenceArgument::class);
+
+        $tracer->startSpan(
+            self::OPERATION_NAME,
+            ['references' => [Reference::create(Reference::CHILD_OF, $notAMockContext)]]
+        );
     }
 
     public function testInjectWithNoInjectorsFails()


### PR DESCRIPTION
### Short description of what this PR does:
- adds a test for `startSpan()` with references
- fixes the incompatibility mentioned in the issue
- increases the phpstan level (this would have caught the issue as well)

Closes #91 