### PR TITLE
Ensure carrier is passed by reference in MockTracer::inject

### DIFF
--- a/src/OpenTracing/Mock/MockTracer.php
+++ b/src/OpenTracing/Mock/MockTracer.php
@@ -97,7 +97,7 @@ final class MockTracer implements Tracer
             throw UnsupportedFormat::forFormat($format);
         }
 
-        call_user_func($this->injectors[$format], $spanContext, $carrier);
+        $this->injectors[$format]($spanContext, $carrier);
     }
 
     /**
@@ -109,7 +109,7 @@ final class MockTracer implements Tracer
             throw UnsupportedFormat::forFormat($format);
         }
 
-        return call_user_func($this->extractors[$format], $carrier);
+        return $this->extractors[$format]($carrier);
     }
 
     /**

--- a/tests/OpenTracing/Mock/MockTracerTest.php
+++ b/tests/OpenTracing/Mock/MockTracerTest.php
@@ -80,7 +80,7 @@ final class MockTracerTest extends TestCase
         $actualSpanContext = null;
         $actualCarrier = null;
 
-        $injector = function ($spanContext, $carrier) use (&$actualSpanContext, &$actualCarrier) {
+        $injector = function ($spanContext, &$carrier) use (&$actualSpanContext, &$actualCarrier) {
             $actualSpanContext = $spanContext;
             $actualCarrier = $carrier;
         };


### PR DESCRIPTION
### Short description of what this PR does:
The `MockTracer` class provided by opentracing-php allows users to provide callables
implementing tracing context injection for a given format. The inject() method implementation,
when called with a given context, format and carrier, looks up the user-provided callable for the given format,
and invokes it via PHP's `call_user_func` function to perform the injection.

This implementation is broken, because `call_user_func` passes parameters to the target by value,
rather than by reference.[1] Since the injection process relies on the carrier being passed by reference,
so that the injection callable can modify the carrier, this will cause a PHP Warning and cause the injection to fail, e.g.:

> Parameter 2 to OpenTracing\Tests\Mock\MockTracerTest::OpenTracing\Tests\Mock\{closure}() expected to be a reference, value given

This patch changes MockTracer::inject to invoke the injector callable directly rather than via call_user_func, and updates
the corresponding unit test.

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

Closes #106 