### PR TITLE
Add return type Traversable to getIterator for php8.1 compatibility

### DIFF
--- a/src/OpenTracing/NoopSpanContext.php
+++ b/src/OpenTracing/NoopSpanContext.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace OpenTracing;
 
 use EmptyIterator;
+use Traversable;
 
 final class NoopSpanContext implements SpanContext
 {
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new EmptyIterator();
     }


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

Please don't open huge pull requests and keep one pull request solving one problem.

Please enter the issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->

### Short description of what this PR does:
- Adds return type to OpenTracing/NoopSpanContext::getIterator() method

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

Closes #119